### PR TITLE
Add new interactive effects + variate controls per piece type

### DIFF
--- a/client/src/components/PieceControlPanel.vue
+++ b/client/src/components/PieceControlPanel.vue
@@ -30,8 +30,11 @@
         </div>
       </div>
       <div class="one-shot-triggers">
-        <h3 class="triggerables-title">Tap to Run Special Pattern</h3>
+        <h3 class="triggerables-title">Tap to Run Special Effects</h3>
         <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('fire')">🔥</button>
+        <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('candy-chaos')">🍭</button>
+        <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('white')">🏳</button>
+        <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('rainbow')">🌈</button>
       </div>
     </span>
     <div>

--- a/client/src/components/PieceControlPanel.vue
+++ b/client/src/components/PieceControlPanel.vue
@@ -2,34 +2,37 @@
   <div>
     <h1 class="controller-title">Entwined Controller</h1>
     <h2 class="still-there-message" v-if="inactivityDeadline">Still there? Your session will end if you don't use the controls in the next {{inactivitySecondsRemaining}} seconds.</h2>
-    <div class="row setting-row">
+    <div class="row setting-row" v-if="audioControlAvailable && (pieceConfig.allControls || pieceConfig.type === 'fairy-circle')">
       <div class="col">
         <button type="button" class="mic-button mic-button-start" v-on:click="startAudioControl()" v-if="audioControlAvailable && !audioControlEnabled" aria-label="Start Microphone Control"></button>
         <button type="button" class="mic-button mic-button-stop" v-on:click="stopAudioControl()" v-if="audioControlAvailable && audioControlEnabled" aria-label="Stop Microphone Control"></button>
         <p class="sing-instructions" v-if="audioControlEnabled">Sing into your microphone to make the magic happen!</p>
+        <p class="sing-instructions" v-if="audioControlEnabled">Hint: singing works better than speaking.</p>
         <p class="audio-error" v-if="audioControlError">Something went wrong accessing your microphone.</p>
       </div>
     </div>
     <span class="main-settings" v-if="!audioControlEnabled">
-      <div class="row setting-row">
-        <div class="col">
-          <label for="huePicker">Hue</label>
-          <hue-slider id="huePicker" v-model="selectedColor" :swatches="[]" />
+      <span v-if="pieceConfig.allControls || pieceConfig.type === 'classic' || pieceConfig.type === 'sapling' || (pieceConfig.type === 'fairy-circle' && !audioControlAvailable)">
+        <div class="row setting-row">
+          <div class="col">
+            <label for="huePicker">Hue</label>
+            <hue-slider id="huePicker" v-model="selectedColor" :swatches="[]" />
+          </div>
         </div>
-      </div>
-      <div class="row setting-row">
-        <div class="col">
-          <label for="saturation">Saturation</label>
-          <input type="range" class="form-range" id="saturation" name="saturation"
-              min="0" max="100" v-model.number="saturation">
+        <div class="row setting-row">
+          <div class="col">
+            <label for="saturation">Saturation</label>
+            <input type="range" class="form-range" id="saturation" name="saturation"
+                min="0" max="100" v-model.number="saturation">
+          </div>
+          <div class="col">
+            <label for="brightness">Brightness</label>
+            <input type="range" class="form-range" id="brightness" name="brightness"
+                min="0" max="100" v-model.number="brightness">
+          </div>
         </div>
-        <div class="col">
-          <label for="brightness">Brightness</label>
-          <input type="range" class="form-range" id="brightness" name="brightness"
-              min="0" max="100" v-model.number="brightness">
-        </div>
-      </div>
-      <div class="one-shot-triggers">
+      </span>
+      <div class="one-shot-triggers" v-if="pieceConfig.allControls || pieceConfig.type === 'king'">
         <h3 class="triggerables-title">Tap to Run Special Effects</h3>
         <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('fire')">🔥</button>
         <button type="button" class="btn btn-outline-primary" ontouchstart="" v-on:click="runOneShotTriggerable('candy-chaos')">🍭</button>
@@ -67,7 +70,7 @@ let makeSettingUpdateFunction = function(key) {
 
 export default {
   name: 'PieceControlPanel',
-  props: ['installationId', 'pieceId', 'sessionExpiryDate'],
+  props: ['installationId', 'pieceId', 'pieceConfig', 'sessionExpiryDate'],
   data() {
     return {
       saturation: 50,

--- a/client/src/views/Piece.vue
+++ b/client/src/views/Piece.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="piece">
     <PieceErrorScreen :errorKey="errorKey" v-if="errorKey"/>
-    <PieceControlPanel :installationId="installationId" :pieceId="pieceId" :sessionExpiryDate="sessionExpiryDate" v-else-if="state === 'active'"/>
+    <PieceControlPanel :installationId="installationId" :pieceId="pieceId" :pieceConfig="pieceConfig" :sessionExpiryDate="sessionExpiryDate" v-else-if="state === 'active'"/>
     <PieceWaitingScreen :estimatedWaitTime="estimatedWaitTime" v-else-if="state === 'waiting'"/>
     <PieceOfferScreen :installationId="installationId" :pieceId="pieceId" :offerExpiryDate="offerExpiryDate" v-else-if="state === 'offered'"/>
     <p v-else-if="state === 'loading'">Loading piece interactivity...</p>
@@ -71,6 +71,11 @@ export default {
       }
 
       return null;
+    },
+    pieceConfig: function() {
+      if (this.pieceId == null || this.pieceId == undefined) return null;
+
+      return installations[this.installationId || 'shrubs'].pieces.find((pieceConfig) => { return String(pieceConfig.id) === String(this.pieceId); });
     }
   },
   watch: {

--- a/config/entwinedInstallations.json
+++ b/config/entwinedInstallations.json
@@ -144,104 +144,64 @@
 		"pieces": [
 			{
 					"id": 0,
-					"ry" : 70,
-					"x" : -290.64,
-					"z" : 441.77
+					"allControls": true
 			}, {
 					"id": 1,
-					"ry" : 100,
-					"x" : -587.09,
-					"z" : 145.32
+					"allControls": true
 			},{
 					"id": 2,
-					"ry" : 90,
-					"x" : -227.06,
-					"z" : 145.3
+					"allControls": true
 			},{
 					"id": 3,
-					"ry" : 150,
-					"x" : -595.8,
-					"z" : -154.4
+					"allControls": true
 			},{
 					"id": 4,
-					"ry" : 180,
-					"x" : -299.7,
-					"z" : -236.1
+					"allControls": true
 			},{
 					"id": 5,
-					"ry" : -110,
-					"x" : 86.3,
-					"z" : -540.4
+					"allControls": true
 			},{
 					"id": 6,
-					"ry" : -90,
-					"x" : 218,
-					"z" : -258.8
+					"allControls": true
 			},{
 					"id": 7,
-					"ry" : -60,
-					"x" : 585.8,
-					"z" : -172.6
+					"allControls": true
 			},{
 					"id": 8,
-					"ry" : -90,
-					"x" : 694.8,
-					"z" : -472.3
+					"allControls": true
 			},{
 					"id": 9,
-					"ry" : 180,
-					"x" : -467.7,
-					"z" : -776.6
+					"allControls": true
 			},{
 					"id": 10,
-					"ry" : 200,
-					"x" : -376.9,
-					"z" : -1089.9
+					"allControls": true
 			},{
 					"id": 11,
-					"ry" : -120,
-					"x" : 36.3,
-					"z" : -917.3
+					"allControls": true
 			},{
 					"id": 12,
-					"ry" : -90,
-					"x" : 190.7,
-					"z" : -1126.2
+					"allControls": true
 			},{
 					"id": 13,
-					"ry" : -120,
-					"x" : 95.4,
-					"z" : -1362.4
+					"allControls": true
 			},{
 					"id": 14,
-					"ry" : -20,
-					"x" : 971.8,
-					"z" : 54.5
+					"allControls": true
 			},{
 					"id": 15,
-					"ry" : -20,
-					"x" : 590.4,
-					"z" : 354.2
+					"allControls": true
 			},{
 					"id": 16,
-					"ry" : 0,
-					"x" : 472.3,
-					"z" : 590.4
+					"allControls": true
 			},{
 					"id": 17,
-					"ry" : -20,
-					"x" : 944.6,
-					"z" : 617.6
+					"allControls": true
 			},{
 					"id": 18,
-					"ry" : -30,
-					"x" : 1121.7,
-					"z" : 332.4
+					"allControls": true
 			},{
 					"id": 19,
-					"ry" : -30,
-					"x" : 1389.6,
-					"z" : 354.2
+					"allControls": true
 			}]
 	},
 	"950arnold": {
@@ -262,7 +222,8 @@
 		"pieces": [
 			{
 					"id": "yard",
-					"type" : "classic"
+					"type" : "classic",
+					"allControls": true
 			}
 		]
 	},
@@ -270,22 +231,27 @@
 		"pieces": [
 			{
 				"id": "front",
-				"type" : "classic"
+				"type" : "classic",
+				"allControls": true
 			},
 			{
 				"id": "middle",
-				"type" : "classic"
+				"type" : "classic",
+				"allControls": true
 			},
 			{
 				"id": "rear",
-				"type" : "classic"
+				"type" : "classic",
+				"allControls": true
 			}
 		]
 	},
 	"marin-home": {
 		"pieces": [
 			{
-				"id": "shrub"
+				"id": "shrub",
+				"type": "classic",
+				"allControls": true
 			}
 		]
 	}


### PR DESCRIPTION
Two changes:

1) Adds new interactive effects Candy Chaos, Rainbow, and White.

2) Varies effects by piece type at GGP, so that king shrubs will only show triggerable buttons, classic shrubs will only show sliders, and fairy circles will only show microphone input.

This must be merged _after_ this change on the Entwined repo: https://github.com/squaredproject/Entwined/pull/56